### PR TITLE
Refactor scala files

### DIFF
--- a/dblibj/scalastyle-config.xml
+++ b/dblibj/scalastyle-config.xml
@@ -81,7 +81,7 @@
  </check>
  <check level="warning" class="org.scalastyle.scalariform.NumberOfTypesChecker" enabled="true">
   <parameters>
-   <parameter name="maxTypes"><![CDATA[30]]></parameter>
+   <parameter name="maxTypes"><![CDATA[50]]></parameter>
   </parameters>
  </check>
  <check level="warning" class="org.scalastyle.scalariform.CyclomaticComplexityChecker" enabled="true">

--- a/dblibj/scalastyle-config.xml
+++ b/dblibj/scalastyle-config.xml
@@ -109,7 +109,7 @@
  </check>
  <check level="warning" class="org.scalastyle.scalariform.NumberOfMethodsInTypeChecker" enabled="true">
   <parameters>
-   <parameter name="maxMethods"><![CDATA[30]]></parameter>
+   <parameter name="maxMethods"><![CDATA[50]]></parameter>
   </parameters>
  </check>
  <check level="warning" class="org.scalastyle.scalariform.PublicMethodsHaveTypeChecker" enabled="true"></check>

--- a/dblibj/scalastyle-config.xml
+++ b/dblibj/scalastyle-config.xml
@@ -1,11 +1,11 @@
 <scalastyle>
  <name>Scalastyle standard configuration</name>
  <check level="warning" class="org.scalastyle.file.FileTabChecker" enabled="true"></check>
- <check level="warning" class="org.scalastyle.file.FileLengthChecker" enabled="true">
+ <!--<check level="warning" class="org.scalastyle.file.FileLengthChecker" enabled="true">
   <parameters>
    <parameter name="maxFileLength"><![CDATA[800]]></parameter>
   </parameters>
- </check>
+ </check>-->
  <!--<check level="warning" class="org.scalastyle.file.HeaderMatchesChecker" enabled="true">
   <parameters>
    <parameter name="header"><![CDATA[// Copyright (C) 2011-2012 the original author or authors.

--- a/dblibj/scalastyle-config.xml
+++ b/dblibj/scalastyle-config.xml
@@ -6,7 +6,7 @@
    <parameter name="maxFileLength"><![CDATA[800]]></parameter>
   </parameters>
  </check>
- <check level="warning" class="org.scalastyle.file.HeaderMatchesChecker" enabled="true">
+ <!--<check level="warning" class="org.scalastyle.file.HeaderMatchesChecker" enabled="true">
   <parameters>
    <parameter name="header"><![CDATA[// Copyright (C) 2011-2012 the original author or authors.
 // See the LICENCE.txt file distributed with this work for additional
@@ -24,7 +24,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.]]></parameter>
   </parameters>
- </check>
+ </check>-->
  <check level="warning" class="org.scalastyle.scalariform.SpacesAfterPlusChecker" enabled="true"></check>
  <check level="warning" class="org.scalastyle.file.WhitespaceEndOfLineChecker" enabled="true"></check>
  <check level="warning" class="org.scalastyle.scalariform.SpacesBeforePlusChecker" enabled="true"></check>
@@ -60,14 +60,15 @@
    <parameter name="maxParameters"><![CDATA[8]]></parameter>
   </parameters>
  </check>
- <check level="warning" class="org.scalastyle.scalariform.MagicNumberChecker" enabled="true">
+ <!--<check level="warning" class="org.scalastyle.scalariform.MagicNumberChecker" enabled="true">
   <parameters>
    <parameter name="ignore"><![CDATA[-1,0,1,2,3]]></parameter>
   </parameters>
  </check>
+ -->
  <check level="warning" class="org.scalastyle.scalariform.NoWhitespaceBeforeLeftBracketChecker" enabled="true"></check>
  <check level="warning" class="org.scalastyle.scalariform.NoWhitespaceAfterLeftBracketChecker" enabled="true"></check>
- <check level="warning" class="org.scalastyle.scalariform.ReturnChecker" enabled="true"></check>
+ <!--<check level="warning" class="org.scalastyle.scalariform.ReturnChecker" enabled="true"></check>-->
  <check level="warning" class="org.scalastyle.scalariform.NullChecker" enabled="true"></check>
  <check level="warning" class="org.scalastyle.scalariform.NoCloneChecker" enabled="true"></check>
  <check level="warning" class="org.scalastyle.scalariform.NoFinalizeChecker" enabled="true"></check>

--- a/dblibj/src/main/scala/Common.scala
+++ b/dblibj/src/main/scala/Common.scala
@@ -363,7 +363,7 @@ object Common {
     updateConnList(key, (_ => c), state)
 
   def setLibErrorStatus(errorCode: SqlCode, state: OCDBState): Int =
-    OCDB_PGsetLibErrorStatus(errorCode, state)
+    ocdbPGsetLibErrorStatus(errorCode, state)
 
   def setResultStatus(id: Int, state: OCDBState): Boolean =
     lookUpConnList(id, state) match {
@@ -444,7 +444,7 @@ object Common {
     Common.resolveCONNID(cid, state.globalState.connectionMap)
   }
 
-  def OCDB_PGsetLibErrorStatus(errorCode: SqlCode, state: OCDBState): Int = {
+  def ocdbPGsetLibErrorStatus(errorCode: SqlCode, state: OCDBState): Int = {
     val (code, sqlState) = errorCode match {
       case OCDB_NO_ERROR()           => (OCPG_NO_ERROR, "00000")
       case OCDB_NOT_FOUND()          => (OCPG_NOT_FOUND, "02000")

--- a/dblibj/src/main/scala/Common.scala
+++ b/dblibj/src/main/scala/Common.scala
@@ -368,10 +368,10 @@ object Common {
   def setResultStatus(id: Int, state: OCDBState): Boolean =
     lookUpConnList(id, state) match {
       case None             => false
-      case Some((_, pConn)) => OCDB_PGsetResultStatus(pConn.result, state)
+      case Some((_, pConn)) => ocdbPGsetResultStatus(pConn.result, state)
     }
 
-  def OCDB_PGsetResultStatus(result: ExecResult, state: OCDBState): Boolean = {
+  def ocdbPGsetResultStatus(result: ExecResult, state: OCDBState): Boolean = {
     val (sqlCode, sqlState) = result match {
       case Right(_) => {
         (OCPG_NO_ERROR, "00000")
@@ -418,7 +418,7 @@ object Common {
     return result.isRight
   }
 
-  /** Implementation of OCDB_PGSetResultStatus in dblib/ocpgsql.c
+  /** Implementation of ocdbPGsetResultStatus in dblib/ocpgsql.c
     * (Open-COBOL-ESQL) Regardless of the pretious SQL execution, sqlErrorCode
     * is zero. If the pretious SQL execution fails, sqlState equals to
     * PSQLState.

--- a/dblibj/src/main/scala/Connect.scala
+++ b/dblibj/src/main/scala/Connect.scala
@@ -105,7 +105,7 @@ object OCESQLConnectCore {
     }
 
     // [remark] トランザクションがどこでとじられるのか不明のため一時的に消去
-    OCDBExec(connectId, "BEGIN", state)
+    ocdbExec(connectId, "BEGIN", state)
 
     if (setResultStatus(connectId, state)) {
       return 1
@@ -206,7 +206,7 @@ object OCESQLConnectCore {
     val returnValue = addConnList(dbType, connName, connAddr, state)
 
     if (returnValue == INVALID_CONN_ID) {
-      OCDB_PGFinish(connAddr, state)
+      ocdbPGFinish(connAddr, state)
       return INVALID_CONN_ID
     }
 

--- a/dblibj/src/main/scala/Connect.scala
+++ b/dblibj/src/main/scala/Connect.scala
@@ -186,7 +186,7 @@ object OCESQLConnectCore {
       encoding: String,
       state: OCDBState
   ): Int = {
-    val connAddr = OCDB_PGconnect(
+    val connAddr = ocdbPGconnect(
       dbname,
       host,
       port,
@@ -272,7 +272,7 @@ object OCESQLConnectCore {
     state.updateGlobalState(newGlobalState)
   }
 
-  private def OCDB_PGconnect(
+  private def ocdbPGconnect(
       dbname: Option[String],
       host: Option[String],
       port: Option[String],
@@ -282,7 +282,7 @@ object OCESQLConnectCore {
       encoding: String,
       state: OCDBState
   ): Option[Connection] =
-    execute_connect(dbname, host, port, user, passwd, encoding, state) match {
+    executeConnect(dbname, host, port, user, passwd, encoding, state) match {
       case None => None
       case Some(c) => {
         c.setAutoCommit(autoCommit)
@@ -294,7 +294,7 @@ object OCESQLConnectCore {
       }
     }
 
-  private def execute_connect(
+  private def executeConnect(
       dbname: Option[String],
       host: Option[String],
       port: Option[String],

--- a/dblibj/src/main/scala/ConnectionInfo.scala
+++ b/dblibj/src/main/scala/ConnectionInfo.scala
@@ -41,26 +41,28 @@ class ConnectionInfo(
     errorMessage,
     pid
   )
-  def setConnAddr(connAddr: Option[Connection]): ConnectionInfo = new ConnectionInfo(
-    id,
-    cid,
-    dbType,
-    connAddr,
-    resAddr,
-    result,
-    errorMessage,
-    pid
-  )
-  def setResAddr(resAddr: Option[Connection]): ConnectionInfo = new ConnectionInfo(
-    id,
-    cid,
-    dbType,
-    connAddr,
-    resAddr,
-    result,
-    errorMessage,
-    pid
-  )
+  def setConnAddr(connAddr: Option[Connection]): ConnectionInfo =
+    new ConnectionInfo(
+      id,
+      cid,
+      dbType,
+      connAddr,
+      resAddr,
+      result,
+      errorMessage,
+      pid
+    )
+  def setResAddr(resAddr: Option[Connection]): ConnectionInfo =
+    new ConnectionInfo(
+      id,
+      cid,
+      dbType,
+      connAddr,
+      resAddr,
+      result,
+      errorMessage,
+      pid
+    )
   def setResult(result: ExecResult): ConnectionInfo = new ConnectionInfo(
     id,
     cid,
@@ -71,16 +73,17 @@ class ConnectionInfo(
     errorMessage,
     pid
   )
-  def setErrorMessage(errorMessage: Option[String]): ConnectionInfo = new ConnectionInfo(
-    id,
-    cid,
-    dbType,
-    connAddr,
-    resAddr,
-    result,
-    errorMessage,
-    pid
-  )
+  def setErrorMessage(errorMessage: Option[String]): ConnectionInfo =
+    new ConnectionInfo(
+      id,
+      cid,
+      dbType,
+      connAddr,
+      resAddr,
+      result,
+      errorMessage,
+      pid
+    )
   def setPid(pid: Option[String]): ConnectionInfo = new ConnectionInfo(
     id,
     cid,

--- a/dblibj/src/main/scala/ConnectionInfo.scala
+++ b/dblibj/src/main/scala/ConnectionInfo.scala
@@ -11,7 +11,7 @@ class ConnectionInfo(
     val errorMessage: Option[String],
     val pid: Option[String]
 ) {
-  def setId(id: Int) = new ConnectionInfo(
+  def setId(id: Int): ConnectionInfo = new ConnectionInfo(
     id,
     cid,
     dbType,
@@ -21,7 +21,7 @@ class ConnectionInfo(
     errorMessage,
     pid
   )
-  def setCid(cid: String) = new ConnectionInfo(
+  def setCid(cid: String): ConnectionInfo = new ConnectionInfo(
     id,
     cid,
     dbType,
@@ -31,7 +31,7 @@ class ConnectionInfo(
     errorMessage,
     pid
   )
-  def setDbType(dbType: DBtype) = new ConnectionInfo(
+  def setDbType(dbType: DBtype): ConnectionInfo = new ConnectionInfo(
     id,
     cid,
     dbType,
@@ -41,7 +41,7 @@ class ConnectionInfo(
     errorMessage,
     pid
   )
-  def setConnAddr(connAddr: Option[Connection]) = new ConnectionInfo(
+  def setConnAddr(connAddr: Option[Connection]): ConnectionInfo = new ConnectionInfo(
     id,
     cid,
     dbType,
@@ -51,7 +51,7 @@ class ConnectionInfo(
     errorMessage,
     pid
   )
-  def setResAddr(resAddr: Option[Connection]) = new ConnectionInfo(
+  def setResAddr(resAddr: Option[Connection]): ConnectionInfo = new ConnectionInfo(
     id,
     cid,
     dbType,
@@ -61,7 +61,7 @@ class ConnectionInfo(
     errorMessage,
     pid
   )
-  def setResult(result: ExecResult) = new ConnectionInfo(
+  def setResult(result: ExecResult): ConnectionInfo = new ConnectionInfo(
     id,
     cid,
     dbType,
@@ -71,7 +71,7 @@ class ConnectionInfo(
     errorMessage,
     pid
   )
-  def setErrorMessage(errorMessage: Option[String]) = new ConnectionInfo(
+  def setErrorMessage(errorMessage: Option[String]): ConnectionInfo = new ConnectionInfo(
     id,
     cid,
     dbType,
@@ -81,7 +81,7 @@ class ConnectionInfo(
     errorMessage,
     pid
   )
-  def setPid(pid: Option[String]) = new ConnectionInfo(
+  def setPid(pid: Option[String]): ConnectionInfo = new ConnectionInfo(
     id,
     cid,
     dbType,

--- a/dblibj/src/main/scala/Cursor.scala
+++ b/dblibj/src/main/scala/Cursor.scala
@@ -364,7 +364,7 @@ object Cursor {
       if (setResultStatus(id, state)) {
         if (query == "COMMIT" || query == "ROLLBACK") {
           clearCursorMap(id, state)
-          OCDBExec(id, "BEGIN", state)
+          ocdbExec(id, "BEGIN", state)
         }
         0
       } else {
@@ -378,7 +378,7 @@ object Cursor {
           if (prepare.nParams != nParams) {
             errorProc(prepare)
           } else {
-            OCDBExecParams(
+            ocdbExecParams(
               id,
               prepare.query,
               state.globalState.sqlVarQueue,
@@ -387,7 +387,7 @@ object Cursor {
             endProc(prepare.query)
           }
         } else {
-          OCDBExec(id, prepare.query, state)
+          ocdbExec(id, prepare.query, state)
           endProc(prepare.query)
         }
       case _ => 1
@@ -459,7 +459,7 @@ object Cursor {
     } else {
       s"DECLARE ${cname} CURSOR FOR ${query}"
     }
-    val result = OCDB_PGExec(conn, command)
+    val result = ocdbPGExec(conn, command)
     result match {
       case Left(e) =>
         logLn(e.getMessage())
@@ -482,7 +482,7 @@ object Cursor {
     } else {
       s"DECLARE ${cname} CURSOR FOR ${query}"
     }
-    val result = OCDB_PGExecParam(conn, command, sqlVarQueue)
+    val result = ocdbPGExecParam(conn, command, sqlVarQueue)
     result match {
       case Left(e) =>
         logLn(e.getMessage())
@@ -526,7 +526,7 @@ object Cursor {
       case OCDB_READ_PREVIOUS() => "BACKWARD"
       case _                    => "FORWARD"
     }
-    OCDBExec(conn.id, s"FETCH ${strReadMode} ${count} FROM ${cname}", state)
+    ocdbExec(conn.id, s"FETCH ${strReadMode} ${count} FROM ${cname}", state)
   }
 
   def OCDBCursorFetchOne(
@@ -553,15 +553,15 @@ object Cursor {
   ): Unit = {
     fetchMode match {
       case OCDB_READ_PREVIOUS() =>
-        OCDBExec(
+        ocdbExec(
           conn.id,
           s"FETCH BACKWARD ${GlobalState.getFetchRecords} FROM ${cname}",
           state
         )
       case OCDB_READ_CURRENT() =>
-        OCDBExec(conn.id, s"FETCH FORWARD 0 FROM ${cname}", state)
+        ocdbExec(conn.id, s"FETCH FORWARD 0 FROM ${cname}", state)
       case OCDB_READ_NEXT() =>
-        OCDBExec(
+        ocdbExec(
           conn.id,
           s"FETCH FORWARD ${GlobalState.getFetchRecords} FROM ${cname}",
           state
@@ -583,5 +583,5 @@ object Cursor {
       cname: String,
       state: OCDBState
   ): ExecResult =
-    OCDB_PGExec(conn, s"CLOSE ${cname}")
+    ocdbPGExec(conn, s"CLOSE ${cname}")
 }

--- a/dblibj/src/main/scala/Cursor.scala
+++ b/dblibj/src/main/scala/Cursor.scala
@@ -394,7 +394,7 @@ object Cursor {
     }
   }
 
-  def OCDBCursorDeclare(
+  def ocdbCursorDeclare(
       id: Int,
       cname: String,
       query: String,
@@ -405,7 +405,7 @@ object Cursor {
       case None => ()
       case Some((_, pConn)) => {
         val result =
-          OCDB_PGCursorDeclear(pConn.connAddr, cname, query, withHold, state)
+          ocdbPGCursorDeclear(pConn.connAddr, cname, query, withHold, state)
         result match {
           case Right(EResultSet(rs)) =>
             updateConnList(id, pConn.setResult(result), state)
@@ -417,7 +417,7 @@ object Cursor {
       }
     }
 
-  def OCDBCursorDeclareParams(
+  def ocdbCursorDeclareParams(
       id: Int,
       cname: String,
       query: String,
@@ -428,7 +428,7 @@ object Cursor {
     lookUpConnList(id, state) match {
       case None => ()
       case Some((_, pConn)) => {
-        val result = OCDB_PGCursorDeclareParams(
+        val result = ocdbPGCursorDeclareParams(
           pConn.connAddr,
           cname,
           query,
@@ -447,7 +447,7 @@ object Cursor {
       }
     }
 
-  def OCDB_PGCursorDeclear(
+  def ocdbPGCursorDeclear(
       conn: Option[Connection],
       cname: String,
       query: String,
@@ -469,7 +469,7 @@ object Cursor {
     result
   }
 
-  def OCDB_PGCursorDeclareParams(
+  def ocdbPGCursorDeclareParams(
       conn: Option[Connection],
       cname: String,
       query: String,
@@ -492,14 +492,14 @@ object Cursor {
     result
   }
 
-  def OCDBCursorOpen(id: Int, cname: String, state: OCDBState): Unit =
+  def ocdbCursorOpen(id: Int, cname: String, state: OCDBState): Unit =
     lookUpConnList(id, state) match {
       case None => ()
       case Some((_, pConn)) =>
         updateConnList(id, pConn.setResult(Right(ESuccess())), state)
     }
 
-  def OCDBCursorFetchOccurs(
+  def ocdbCursorFetchOccurs(
       id: Int,
       cname: String,
       fetchMode: ReadDirection,
@@ -511,11 +511,11 @@ object Cursor {
       case Some((_, pConn)) => {
         logLn(s"addr:${pConn.connAddr
             .getOrElse("")}, cname:${cname}, mode:${fetchMode}, count:${count}")
-        OCDB_PGCursorFetchOccurs(pConn, cname, fetchMode, count, state)
+        ocdbPGCursorFetchOccurs(pConn, cname, fetchMode, count, state)
       }
     }
 
-  def OCDB_PGCursorFetchOccurs(
+  def ocdbPGCursorFetchOccurs(
       conn: ConnectionInfo,
       cname: String,
       fetchMode: ReadDirection,
@@ -529,7 +529,7 @@ object Cursor {
     ocdbExec(conn.id, s"FETCH ${strReadMode} ${count} FROM ${cname}", state)
   }
 
-  def OCDBCursorFetchOne(
+  def ocdbCursorFetchOne(
       id: Int,
       cname: String,
       fetchMode: ReadDirection,
@@ -541,11 +541,11 @@ object Cursor {
         logLn(
           s"addr:${pConn.connAddr.getOrElse("")}, cname:${cname}, mode:${fetchMode}"
         )
-        OCDB_PGCursorFetchOne(pConn, cname, fetchMode, state)
+        ocdbPGCursorFetchOne(pConn, cname, fetchMode, state)
       }
     }
 
-  def OCDB_PGCursorFetchOne(
+  def ocdbPGCursorFetchOne(
       conn: ConnectionInfo,
       cname: String,
       fetchMode: ReadDirection,
@@ -569,16 +569,16 @@ object Cursor {
     }
   }
 
-  def OCDBCursorClose(id: Int, cname: String, state: OCDBState): Unit =
+  def ocdbCursorClose(id: Int, cname: String, state: OCDBState): Unit =
     lookUpConnList(id, state) match {
       case None => ()
       case Some((_, pConn)) => {
-        val res = OCDB_PGCursorClose(pConn.connAddr, cname, state)
+        val res = ocdbPGCursorClose(pConn.connAddr, cname, state)
         updateConnList(id, pConn.setResult(res), state)
       }
     }
 
-  def OCDB_PGCursorClose(
+  def ocdbPGCursorClose(
       conn: Option[Connection],
       cname: String,
       state: OCDBState

--- a/dblibj/src/main/scala/Disconnect.scala
+++ b/dblibj/src/main/scala/Disconnect.scala
@@ -2,7 +2,7 @@ import Common._
 
 object OCESQLDisconnectCore {
   def disconnect(id: Int, state: OCDBState): Unit = {
-    OCDBExec(id, "COMMIT", state)
-    OCDB_Finish(id, state)
+    ocdbExec(id, "COMMIT", state)
+    ocdbFinish(id, state)
   }
 }

--- a/dblibj/src/main/scala/GlobalState.scala
+++ b/dblibj/src/main/scala/GlobalState.scala
@@ -92,8 +92,8 @@ object GlobalState {
   val SWITCH_PIC_N_ENV_VAR_NAME = "OCESQL4J_UTF16BE"
   val FETCH_RECORDS_ENV_VAR_NAME = "OCESQL4J_FETCH_RECORDS"
 
-  def getFetchRecords = fetch_records
-  def setFetchRecords(x: Int) = {
+  def getFetchRecords: Int = fetch_records
+  def setFetchRecords(x: Int): Unit = {
     if (x > 0) {
       fetch_records = x
     }

--- a/dblibj/src/main/scala/Main.scala
+++ b/dblibj/src/main/scala/Main.scala
@@ -707,7 +707,7 @@ class OCESQLCursorFetchOne extends CobolRunnableWrapper {
       return 1
     }
 
-    val fields = OCDBNfields(id, state)
+    val fields = ocdbNfields(id, state)
 
     if (fields != state.globalState.sqlResVarQueue.length) {
       errorLogLn(
@@ -742,7 +742,7 @@ class OCESQLCursorFetchOne extends CobolRunnableWrapper {
                   ) {
                     if (i < fields) {
                       fetchRecord =
-                        fetchRecord ::: List(OCDBGetValue(rs, sv, i + 1))
+                        fetchRecord ::: List(ocdbGetValue(rs, sv, i + 1))
                     }
                   }
                   fetchRecords = fetchRecords ::: List(fetchRecord)
@@ -872,7 +872,7 @@ class OCESQLCursorFetchOccurs extends CobolRunnableWrapper {
         if (state.sqlCA.code < 0) {
           return 1
         }
-        val fields = OCDBNfields(id, state)
+        val fields = ocdbNfields(id, state)
 
         if (fields != state.globalState.sqlResVarQueue.length) {
           errorLogLn(

--- a/dblibj/src/main/scala/Main.scala
+++ b/dblibj/src/main/scala/Main.scala
@@ -568,7 +568,7 @@ class OCESQLCursorOpen extends CobolRunnableWrapper {
     if (cursor.nParams > 0) {
       // TODO the following code should be improved
       val args = cursor.sqlVarQueue.map(sv => createRealData(sv, 0, state))
-      OCDBCursorDeclareParams(
+      ocdbCursorDeclareParams(
         cursor.connId,
         cursor.name,
         cursor.query,
@@ -579,7 +579,7 @@ class OCESQLCursorOpen extends CobolRunnableWrapper {
     } else {
       cursor.sp match {
         case q :: _ =>
-          OCDBCursorDeclare(
+          ocdbCursorDeclare(
             cursor.connId,
             cursor.name,
             q.query,
@@ -587,7 +587,7 @@ class OCESQLCursorOpen extends CobolRunnableWrapper {
             state
           )
         case _ =>
-          OCDBCursorDeclare(
+          ocdbCursorDeclare(
             cursor.connId,
             cursor.name,
             cursor.query,
@@ -601,7 +601,7 @@ class OCESQLCursorOpen extends CobolRunnableWrapper {
       return 1
     }
 
-    OCDBCursorOpen(cursor.connId, name, state)
+    ocdbCursorOpen(cursor.connId, name, state)
     if (!setResultStatus(cursor.connId, state)) {
       return 1
     }
@@ -679,7 +679,7 @@ class OCESQLCursorOpenParams extends CobolRunnableWrapper {
       return 1
     }
 
-    OCDBCursorOpen(cursor.connId, name, state)
+    ocdbCursorOpen(cursor.connId, name, state)
     if (!setResultStatus(cursor.connId, state)) {
       return 1
     }
@@ -701,7 +701,7 @@ class OCESQLCursorFetchOne extends CobolRunnableWrapper {
       cname: Option[String],
       id: Int
   ): Int = {
-    OCDBCursorFetchOne(id, name, OCDB_READ_NEXT(), state)
+    ocdbCursorFetchOne(id, name, OCDB_READ_NEXT(), state)
     val resultStatus = setResultStatus(id, state)
     if (!resultStatus) {
       return 1
@@ -862,7 +862,7 @@ class OCESQLCursorFetchOccurs extends CobolRunnableWrapper {
       }
       case Some(cursor) => {
         val id = cursor.connId
-        OCDBCursorFetchOccurs(
+        ocdbCursorFetchOccurs(
           id,
           name,
           OCDB_READ_NEXT(),
@@ -953,7 +953,7 @@ class OCESQLCursorClose extends CobolRunnableWrapper {
         }
         case Some(cursor) => {
           logLn(s"Connect ID: ${cursor.connId}")
-          OCDBCursorClose(cursor.connId, name, state)
+          ocdbCursorClose(cursor.connId, name, state)
           if (setResultStatus(cursor.connId, state)) {
             updateCursorMap(name, cursor.setIsOpened(false), state)
             return 0

--- a/dblibj/src/main/scala/OccursInfo.scala
+++ b/dblibj/src/main/scala/OccursInfo.scala
@@ -7,5 +7,5 @@ class OccursInfo(val iter: Int, val length: Int, val isPresent: Boolean) {
 }
 
 object OccursInfo {
-  def defaultValue = new OccursInfo(0, 0, false)
+  def defaultValue: OccursInfo = new OccursInfo(0, 0, false)
 }

--- a/dblibj/src/main/scala/QueryInfo.scala
+++ b/dblibj/src/main/scala/QueryInfo.scala
@@ -1,5 +1,5 @@
 class QueryInfo(val pName: String, val query: String, val nParams: Int) {}
 
 object QueryInfo {
-  def defaultValue = new QueryInfo("", "", 0)
+  def defaultValue: QueryInfo = new QueryInfo("", "", 0)
 }

--- a/dblibj/src/main/scala/SQLVar.scala
+++ b/dblibj/src/main/scala/SQLVar.scala
@@ -104,7 +104,7 @@ class SQLVar(
 }
 
 object SQLVar {
-  def defaultValue = new SQLVar(0, 0, 0, None, None, None, 0)
+  def defaultValue: SQLVar = new SQLVar(0, 0, 0, None, None, None, 0)
 
   def resetSqlVarQueue(state: OCDBState): Unit = {
     val globalState = state.globalState

--- a/dblibj/src/main/scala/Select.scala
+++ b/dblibj/src/main/scala/Select.scala
@@ -52,7 +52,7 @@ object Select {
       return ()
     }
 
-    val fields = OCDBNfields(id, state)
+    val fields = ocdbNfields(id, state)
     if (fields != nResParams) {
       errorLogLn(
         s"ResParams(${nResParams}) and fields(${fields}) are different"
@@ -69,7 +69,7 @@ object Select {
             if (i >= fields) {
               ()
             } else {
-              OCDBGetValue(rs, sv, i + 1) match {
+              ocdbGetValue(rs, sv, i + 1) match {
                 case Some(str) =>
                   createCobolData(sv, 0, str, state.globalState.occursInfo)
                 case _ => ()
@@ -106,7 +106,7 @@ object Select {
       return ()
     }
 
-    val fields = OCDBNfields(id, state)
+    val fields = ocdbNfields(id, state)
     if (fields != nResParams) {
       errorLogLn(
         s"ResParams(${nResParams}) and fields(${fields}) are different"
@@ -138,7 +138,7 @@ object Select {
     for (index <- 0 until occursInfo.iter) {
       if (rs.next()) {
         for ((sv, j) <- sqlVarQueue.zipWithIndex) {
-          OCDBGetValue(rs, sv, j + 1) match {
+          ocdbGetValue(rs, sv, j + 1) match {
             case None         => ()
             case Some(retStr) => createCobolData(sv, index, retStr, occursInfo)
           }
@@ -167,7 +167,7 @@ object Select {
     while (rs.next()) {
       rowNum = rowNum + 1
       for ((sv, j) <- sqlVarQueue.zipWithIndex) {
-        var retStrA = OCDBGetValue(rs, sv, j + 1)
+        var retStrA = ocdbGetValue(rs, sv, j + 1)
         var retStr: Array[Byte] = retStrA.get
         var ret = createCobolData(sv, rowNum - 1, retStr, occursInfo)
       }
@@ -175,7 +175,7 @@ object Select {
     rowNum
   }
 
-  def OCDB_PGntuples(conn: ConnectionInfo): Int =
+  def ocdbPGntuples(conn: ConnectionInfo): Int =
     conn.result match {
       case Right(EResultSet(rs)) => {
         rs.last()
@@ -186,13 +186,13 @@ object Select {
       case _ => OCDB_INVALID_NUMBER
     }
 
-  def OCDBNfields(id: Int, state: OCDBState): Int =
+  def ocdbNfields(id: Int, state: OCDBState): Int =
     lookUpConnList(id, state) match {
       case None             => OCDB_INVALID_NUMBER
-      case Some((_, pConn)) => OCDB_PGnfields(pConn)
+      case Some((_, pConn)) => ocdbPGnfields(pConn)
     }
 
-  def OCDB_PGnfields(conn: ConnectionInfo): Int = {
+  def ocdbPGnfields(conn: ConnectionInfo): Int = {
     conn.result match {
       case Right(EResultSet(rs)) => rs.getMetaData.getColumnCount
       case Right(_)              => OCDB_INVALID_NUMBER
@@ -202,7 +202,7 @@ object Select {
 
   val dateFormatter = new SimpleDateFormat("YYYY-MM-dd HH:mm:ss")
 
-  def OCDBGetValue(rs: ResultSet, sv: SQLVar, i: Int): Option[Array[Byte]] = {
+  def ocdbGetValue(rs: ResultSet, sv: SQLVar, i: Int): Option[Array[Byte]] = {
     lazy val stringConverter = {
       for {
         s <- Option(rs.getString(i))

--- a/dblibj/src/main/scala/SqlCA.scala
+++ b/dblibj/src/main/scala/SqlCA.scala
@@ -82,7 +82,7 @@ class SqlCA(
 
 object SqlCA {
   val SQLERRMC_LEN: Int = 70
-  def defaultValue =
+  def defaultValue: SqlCA =
     new SqlCA(
       getArray(0, 8),
       0,


### PR DESCRIPTION
According to the analysis result by scalastyle, scala files are refactored and some warnings are resolved.
* Disable some unnecessary scalastyle rules and change parameters of some rules
* Add return types of public methods
* Rename methods
* Decrease the cyclomatic complexity of `ocesqlExecWhereCurrentOf`

Note: 32 warnings remain.