### PR TITLE
Change the condition of creating an issue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,7 +139,7 @@ jobs:
   # Create an issue if one or more tests fail in scheduled tests
   create-issue-on-failure:
     needs: Open-COBOL-ESQL-4j-tests
-    if: failure() && github.event_name == 'schedule'
+    if: failure() && github.event_name == 'schedule' && github.actor == 'opensourcecobol'
     runs-on: ubuntu-latest
     steps:
       - name: Create an Issue


### PR DESCRIPTION
Change the workflow in order to post a new issue if scheduled builds of **the original repository** fail.
When scheduled builds of forked repositories fail, no issue will be created.