### PR TITLE
Use PostgreSQL JDBC as an external jar

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -10,6 +10,7 @@ env:
   COBOL4J_LIB_DIR: /usr/lib/opensourcecobol4j
   COBOL4J_LIBCOBJ_JAR_PATH: /usr/lib/opensourcecobol4j/libcobj.jar
   OCESQL4J_LIB_DIR: /usr/lib/Open-COBOL-ESQL-4j
+  OCESQL4J_POSTGRESQL_JAR_PATH: /usr/lib/Open-COBOL-ESQL-4j/postgresql.jar
   OCESQL4J_OCESQL4J_JAR_PATH: /usr/lib/Open-COBOL-ESQL-4j/ocesql4j.jar
   CLASSPATH: ":/usr/lib/Open-COBOL-ESQL-4j/ocesql4j.jar"
 
@@ -77,6 +78,9 @@ jobs:
       - name: Install Open COBOL ESQL 4J
         run: |
           cp "$COBOL4J_LIBCOBJ_JAR_PATH" dblibj/lib
+          sudo mkdir -p "$OCESQL4J_LIB_DIR"
+          sudo curl -L -o "$OCESQL4J_POSTGRESQL_JAR_PATH" https://jdbc.postgresql.org/download/postgresql-42.2.24.jre6.jar
+          sudo cp "$OCESQL4J_POSTGRESQL_JAR_PATH" dblibj/lib
           sh configure CFLAGS='-fprofile-arcs -ftest-coverage -Werror' --prefix=/usr/
           make
           sudo make install

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -11,6 +11,7 @@ env:
   COBOL4J_LIBCOBJ_JAR_PATH: /usr/lib/opensourcecobol4j/libcobj.jar
   OCESQL4J_LIB_DIR: /usr/lib/Open-COBOL-ESQL-4j
   OCESQL4J_OCESQL4J_JAR_PATH: /usr/lib/Open-COBOL-ESQL-4j/ocesql4j.jar
+  OCESQL4J_POSTGRESQL_JAR_PATH: /usr/lib/Open-COBOL-ESQL-4j/postgresql.jar
   CLASSPATH: ":/usr/lib/Open-COBOL-ESQL-4j/ocesql4j.jar"
 
 
@@ -61,6 +62,9 @@ jobs:
       - name: Build documentation
         run: |
           cp "$COBOL4J_LIBCOBJ_JAR_PATH" dblibj/lib
+          sudo mkdir -p "$OCESQL4J_LIB_DIR"
+          sudo curl -L -o "$OCESQL4J_POSTGRESQL_JAR_PATH" https://jdbc.postgresql.org/download/postgresql-42.2.24.jre6.jar
+          sudo cp "$OCESQL4J_POSTGRESQL_JAR_PATH" dblibj/lib
           cd dblibj/
           sbt doc
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,6 +10,7 @@ env:
   COBOL4J_LIB_DIR: /usr/lib/opensourcecobol4j
   COBOL4J_LIBCOBJ_JAR_PATH: /usr/lib/opensourcecobol4j/libcobj.jar
   OCESQL4J_LIB_DIR: /usr/lib/Open-COBOL-ESQL-4j
+  OCESQL4J_POSTGRESQL_JAR_PATH: /usr/lib/Open-COBOL-ESQL-4j/postgresql.jar
   OCESQL4J_OCESQL4J_JAR_PATH: /usr/lib/Open-COBOL-ESQL-4j/ocesql4j.jar
   CLASSPATH: ":/usr/lib/Open-COBOL-ESQL-4j/ocesql4j.jar"
 
@@ -106,6 +107,9 @@ jobs:
       - name: Install Open COBOL ESQL 4J
         run: |
           cp "$COBOL4J_LIBCOBJ_JAR_PATH" dblibj/lib
+          mkdir -p "$OCESQL4J_LIB_DIR"
+          curl -L -o "$OCESQL4J_POSTGRESQL_JAR_PATH" https://jdbc.postgresql.org/download/postgresql-42.2.24.jre6.jar
+          cp "$OCESQL4J_POSTGRESQL_JAR_PATH" dblibj/lib
           sh configure --prefix=/usr/ CFLAGS='-Werror'
           make
           make install

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -60,6 +60,9 @@ jobs:
       run: |
         cd dblibj
         copy ../opensourcecobol4j/libcobj/app/build/libs/libcobj.jar lib
+        mkdir C:\ocesql4j\lib
+        curl -L -o C:\ocesql4j\lib\postgresql.jar https://jdbc.postgresql.org/download/postgresql-42.2.24.jar
+        copy C:\ocesql4j\lib\postgresql.jar lib
         sbt assembly
     
     - name: Restore NuGet packages of ocesql4j
@@ -77,14 +80,14 @@ jobs:
       working-directory: sample
       run: |
         $env:PATH+=";C:\opensourcecobol4j\bin;C:\ocesql4j\bin;C:\ocesql4j\config"
-        $env:CLASSPATH="C:\opensourcecobol4j\lib\libcobj.jar;C:\ocesql4j\lib\ocesql4j.jar"
+        $env:CLASSPATH=".;C:\opensourcecobol4j\lib\libcobj.jar;C:\ocesql4j\lib\ocesql4j.jar;C:\ocesql4j\lib\postgresql.jar"
         copy ../copy/sqlca.cbl .
         ocesql FETCHTBL.cbl  FETCHTBL.cob
         ocesql INSERTTBL.cbl INSERTTBL.cob
         cobj INSERTTBL.cob
         cobj FETCHTBL.cob
-        java INSERTTBL.java
-        java FETCHTBL.java > sample-result
+        java INSERTTBL
+        java FETCHTBL > sample-result
 
     - name: Compare result of test
       working-directory: sample

--- a/dblibj/build.sbt
+++ b/dblibj/build.sbt
@@ -6,7 +6,6 @@ scalaVersion := "2.13.14"
 
 libraryDependencies ++= Seq(
   "org.scalatest" %% "scalatest" % "3.0.8" % Test,
-  "org.postgresql" % "postgresql" % "42.2.5"
 )
 
 assemblyJarName := "ocesql4j.jar"

--- a/win/install.ps1
+++ b/win/install.ps1
@@ -1,5 +1,10 @@
-mkdir C:\ocesql4j\bin\
-mkdir C:\ocesql4j\lib\
+if (-Not (Test-Path -Path "C:\ocesql4j\bin")) {
+    mkdir C:\ocesql4j\bin\
+}
+
+if (-Not (Test-Path -Path "C:\ocesql4j\lib")) {
+    mkdir C:\ocesql4j\lib\
+}
 
 copy .\x64\Release\ocesql.exe C:\ocesql4j\bin
 copy ..\dblibj\target\scala-2.13\ocesql4j.jar C:\ocesql4j\lib\


### PR DESCRIPTION
Although sbt installs postgresql JDBC in older versions, this pull request changes sbt settings in order to use postgresql JDBC as and an external jar. i.e. users must download postgresql JDBC manually and place it into appropriciate directories.

This change reverts #57.