### PR TITLE
Improve varying test

### DIFF
--- a/tests/cobol_data.src/varying.at
+++ b/tests/cobol_data.src/varying.at
@@ -54,6 +54,7 @@ AT_DATA([prog.cbl], [
       *    PERFORM DISPLAY-TEST-RESULT.
            PERFORM UNTIL SQLCODE NOT = ZERO
               DISPLAY EMP-NAME-ARR
+              MOVE IDX TO EMP-NAME-LEN
               EXEC SQL 
                   FETCH C1 INTO :EMP-NUM1, :EMP-NAME, :EMP-NUM2
               END-EXEC
@@ -193,15 +194,25 @@ Generate:ROLLBACK
 AT_CHECK([${COMPILE_MODULE} prog.cob])
 AT_CHECK([${RUN_MODULE} prog], [0],
 [A         @&t@
++00000001
 AB        @&t@
++00000002
 ABC       @&t@
++00000003
 ABCD      @&t@
++00000004
 ABCDE     @&t@
++00000005
 ABCDEF    @&t@
++00000006
 ABCDEFG   @&t@
++00000007
 ABCDEFGH  @&t@
++00000008
 ABCDEFGHI @&t@
++00000009
 ABCDEFGHIJ
++00000010
 ])
 
 AT_DATA([prog.cbl], [

--- a/tests/cobol_data.src/varying.at
+++ b/tests/cobol_data.src/varying.at
@@ -254,6 +254,7 @@ AT_DATA([prog.cbl], [
       *    PERFORM DISPLAY-TEST-RESULT.
            PERFORM UNTIL SQLCODE NOT = ZERO
               DISPLAY EMP-NAME-ARR
+              DISPLAY EMP-NAME-LEN
               EXEC SQL 
                   FETCH C1 INTO :EMP-NAME
               END-EXEC
@@ -390,15 +391,25 @@ Generate:ROLLBACK
 AT_CHECK([${COMPILE_MODULE} prog.cob])
 AT_CHECK([${RUN_MODULE} prog], [0],
 [0         @&t@
++00000001
 01        @&t@
++00000002
 012       @&t@
++00000003
 0123      @&t@
++00000004
 01234     @&t@
++00000005
 012345    @&t@
++00000006
 0123456   @&t@
++00000007
 01234567  @&t@
++00000008
 012345678 @&t@
++00000009
 0123456789
++00000010
 ])
 
 AT_CLEANUP


### PR DESCRIPTION
This pull request includes several changes to the `tests/cobol_data.src/varying.at` file, focusing on improving the handling and display of employee names and lengths in the COBOL test data.

Changes to COBOL test data:

* Added a line to move the index to `EMP-NAME-LEN` before fetching employee details to ensure the length is correctly set. (`tests/cobol_data.src/varying.at`)
* Added a display of `EMP-NAME-LEN` to the loop fetching employee names to verify the length of each name. (`tests/cobol_data.src/varying.at`)