### PR TITLE
Add guidelines for contributors

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,40 @@
+Thank you for your interest in contributing to Open COBOL ESQL 4J.
+A summary of how to contribute is below.
+
+# Issues
+
+Although any topics related to Open COBOL ESQL 4J can be posted in [Issues](https://github.com/opensourcecobol/Open-COBOL-ESQL-4j/issues), please submit ones written in English or Japanese.
+
+# Pull Requests
+
+We will check pull requests that passed all CI checks running both tests and static code analysis.
+The static analysis checks whether C and Scala source files are formatted using [clang-format](https://clang.llvm.org/docs/ClangFormat.html) and [Scalafmt](https://scalameta.org/scalafmt/) respectively, and whether [Scalastyle](https://www.scalastyle.org/) finds no error and warning in Java source files.
+
+The below sections describe how to setup and run static code analysis.
+
+## Setup Development Environment
+
+We strongly recommend using [Visual Studio Code with Dev Containers](https://code.visualstudio.com/docs/devcontainers/containers) for a consistent development environment. Follow the steps below to set up your development environment.
+
+1. Install [Docker](https://www.docker.com/get-started) on your machine.
+1. Install [Visual Studio Code](https://code.visualstudio.com/).
+1. Install the [Remote - Containers](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers) extension in Visual Studio Code.
+1. Clone the repository with `git clone --recursive`. **Do not forget to specify `--recursive`**.
+1. Open the repository in Visual Studio Code.
+1. Press `Ctrl+Shift+P` and Select `Dev Containers: Reopen in Container`.
+1. Wait for the DevContainer to start up and the build to complete. It may take several minutes to complete this process.
+1. (Optional) Press `Ctrl+Shift+@` to open a new terminal of Visual Studio code.
+1. (Optional) [Setup credentials for git](https://code.visualstudio.com/remote/advancedcontainers/sharing-git-credentials).
+
+> [!CAUTION]
+> In the dev container, [Git Hooks](https://git-scm.com/book/ms/v2/Customizing-Git-Git-Hooks) executes code formatters when starting `git commit` command. It may take a minutes when you run `git commit` for the first time.
+
+## Run static analysis
+
+> [!CAUTION]
+> CI executes formatters and static analysis tools in Almalinux 9. The behavior of these tools may differ from the one in other operatins systems.
+
+### check with clang-format and scalafmt
+
+Run `./format` in the top directory of Open COBOL ESQL 4J.
+If you want to make sure all files are formatted, run `./check-format` in the top directory of Open COBOL ESQL 4J.

--- a/CONTRIBUTING_JP.md
+++ b/CONTRIBUTING_JP.md
@@ -1,0 +1,40 @@
+Open COBOL ESQL 4Jへのコントリビュートを検討頂きありがとうございます。
+下記にコントリビュートの手順を示します。
+
+# Issues
+
+Open COBOL ESQL 4Jに関するトピックを[Issues](https://github.com/opensourcecobol/Open-COBOL-ESQL-4j/issues)に投稿してください。ただし、英語か日本語での記載をお願いします。
+
+# Pull Requests
+CIはテストとコードの静的解析を実行します。
+CIの静的解析はCとScalaのソースコードがそれぞれ[clang-format](https://clang.llvm.org/docs/ClangFormat.html) and [Scalafmt](https://scalameta.org/scalafmt/)で整形されているか、
+[Scalastyle](https://www.scalastyle.org/)によるScalaソースコードの静的解析でエラーや警告が表示されないかをチェックします。
+
+下記にそれぞれのツールのセットアップと使用方法を説明します。
+
+## 開発環境のセットアップ
+
+一貫した開発環境を確保するために、[Visual Studio Code with Dev Containers](https://code.visualstudio.com/docs/devcontainers/containers)の使用を強く推奨します。以下の手順に従って開発環境をセットアップしてください。
+
+1. [Docker](https://www.docker.com/get-started)をインストールします。
+1. [Visual Studio Code](https://code.visualstudio.com/)をインストールします。
+1. Visual Studio Codeに[Remote - Containers](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers)拡張機能をインストールします。
+1. `git clone --recursive`コマンドを使ってリポジトリをクローンします。**`--recursive`を指定するのを忘れないでください。**
+1. Visual Studio Codeでリポジトリを開きます。
+1. `Ctrl+Shift+P`を押して、`Dev Containers: Reopen in Container`を選択します。
+1. DevContainerの起動とビルドが完了するまで待ちます。このプロセスは数分かかることがあります。
+1. （オプション）`Ctrl+Shift+@`を押して、Visual Studio Codeの新しいターミナルを開きます。
+1. （オプション）[gitの認証情報を設定](https://code.visualstudio.com/remote/advancedcontainers/sharing-git-credentials)します。
+
+> [!CAUTION]
+> Dev container内では、[Git Hooks](https://git-scm.com/book/ms/v2/Customizing-Git-Git-Hooks)が`git commit`コマンドを開始する際にコードフォーマッタを実行します。初めて`git commit`を実行する際には数分かかることがあります。
+
+## 静的解析の実行
+
+> [!CAUTION]
+> CIはAlmalinux 9でフォーマッタと静的解析ツールを実行します。これらのツールの動作は他のオペレーティングシステムとは異なる場合があります。
+
+### clang-formatとscalafmt
+
+Open COBOL ESQL 4Jのトップディレクトリで`./format`を実行してください。
+`./check-format`を実行することで、フォーマットが完了したかを確認できます。

--- a/README.md
+++ b/README.md
@@ -161,3 +161,8 @@ After the build is completed, "cobj.exe" will be created in `win\x64\Debug` or `
 #### Set the environment variables
 1. Add `C:\ocesql4j\bin` to "PATH".
 2. Add `C:\ocesql4j\lib\ocesql4j.jar` and `C:\ocesql4j\lib\postgresql.jar` to "CLASSPATH".
+
+# Contributing
+
+Guidelines for contributing to Open COBOL ESQL 4J can be found in [CONTRIBUTING.md](./CONTRIBUTING.md).
+Contributors are listed in https://github.com/opensourcecobol/Open-COBOL-ESQL-4j/graphs/contributors


### PR DESCRIPTION
This pull request updates the contribution guidelines for the Open COBOL ESQL 4J project. It adds detailed instructions for setting up the development environment and running static code analysis, and provides guidelines for submitting issues and pull requests in both English and Japanese.

### Contribution Guidelines:

* [`CONTRIBUTING.md`](diffhunk://#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055R1-R40): Added comprehensive instructions for contributing, including how to set up the development environment using Visual Studio Code with Dev Containers, and how to run static code analysis using clang-format and Scalafmt.
* [`CONTRIBUTING_JP.md`](diffhunk://#diff-705b8bb6459eda70c11dfdf8092eaa3d3d5c7cd93b8e62986bf370df0445e910R1-R40): Added the Japanese version of the contribution guidelines, mirroring the instructions provided in the English `CONTRIBUTING.md`.

### README Update:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R164-R168): Added a section with a link to the contribution guidelines and a link to the list of contributors.