### PR TITLE
chore: remove pre-commit in Dev Container and update documents

### DIFF
--- a/.devcontainer/boot.sh
+++ b/.devcontainer/boot.sh
@@ -20,8 +20,5 @@ make install
 # Set up git config
 git config --global --add safe.directory /workspaces/Open-COBOL-ESQL-4j
 
-# Set up pre-commit hook
-cp .devcontainer/term_settings/pre-commit .git/hooks/pre-commit
-
 # Set up ~/.bashrc
 cat .devcontainer/term_settings/extra_bashrc.sh >> ~/.bashrc

--- a/.devcontainer/term_settings/pre-commit
+++ b/.devcontainer/term_settings/pre-commit
@@ -1,4 +1,0 @@
-#!/bin/bash
-
-./format
-git add -u

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,6 +10,8 @@ Although any topics related to Open COBOL ESQL 4J can be posted in [Issues](http
 We will check pull requests that passed all CI checks running both tests and static code analysis.
 The static analysis checks whether C and Scala source files are formatted using [clang-format](https://clang.llvm.org/docs/ClangFormat.html) and [Scalafmt](https://scalameta.org/scalafmt/) respectively, and whether [Scalastyle](https://www.scalastyle.org/) finds no error and warning in Java source files.
 
+Before you submit pull requests, you should run `./format` in order to format files in this repository.
+
 The below sections describe how to setup and run static code analysis.
 
 ## Setup Development Environment
@@ -26,13 +28,10 @@ We strongly recommend using [Visual Studio Code with Dev Containers](https://cod
 1. (Optional) Press `Ctrl+Shift+@` to open a new terminal of Visual Studio code.
 1. (Optional) [Setup credentials for git](https://code.visualstudio.com/remote/advancedcontainers/sharing-git-credentials).
 
-> [!CAUTION]
-> In the dev container, [Git Hooks](https://git-scm.com/book/ms/v2/Customizing-Git-Git-Hooks) executes code formatters when starting `git commit` command. It may take a minutes when you run `git commit` for the first time.
-
 ## Run static analysis
 
 > [!CAUTION]
-> CI executes formatters and static analysis tools in Almalinux 9. The behavior of these tools may differ from the one in other operatins systems.
+> Since the behavior of these tools may differ from the one in other operatins systems, we recommend that you run `./format` in Visual Studio Code with Dev Containers described in the previous section.
 
 ### check with clang-format and scalafmt
 

--- a/CONTRIBUTING_JP.md
+++ b/CONTRIBUTING_JP.md
@@ -10,6 +10,8 @@ CIはテストとコードの静的解析を実行します。
 CIの静的解析はCとScalaのソースコードがそれぞれ[clang-format](https://clang.llvm.org/docs/ClangFormat.html) and [Scalafmt](https://scalameta.org/scalafmt/)で整形されているか、
 [Scalastyle](https://www.scalastyle.org/)によるScalaソースコードの静的解析でエラーや警告が表示されないかをチェックします。
 
+Pull Request提出時には、./formatを実行してリポジトリ内のコードをフォーマットしてください。
+
 下記にそれぞれのツールのセットアップと使用方法を説明します。
 
 ## 開発環境のセットアップ
@@ -26,13 +28,10 @@ CIの静的解析はCとScalaのソースコードがそれぞれ[clang-format](
 1. （オプション）`Ctrl+Shift+@`を押して、Visual Studio Codeの新しいターミナルを開きます。
 1. （オプション）[gitの認証情報を設定](https://code.visualstudio.com/remote/advancedcontainers/sharing-git-credentials)します。
 
-> [!CAUTION]
-> Dev container内では、[Git Hooks](https://git-scm.com/book/ms/v2/Customizing-Git-Git-Hooks)が`git commit`コマンドを開始する際にコードフォーマッタを実行します。初めて`git commit`を実行する際には数分かかることがあります。
-
 ## 静的解析の実行
 
 > [!CAUTION]
-> CIはAlmalinux 9でフォーマッタと静的解析ツールを実行します。これらのツールの動作は他のオペレーティングシステムとは異なる場合があります。
+> これらのツールの動作は他のオペレーティングシステムとは異なる場合があります。上記のVisual Studio Code with Dev Containersの環境でフォーマッタを実行することを推奨します。
 
 ### clang-formatとscalafmt
 


### PR DESCRIPTION
This pull request includes several updates to the development environment setup and documentation for the Open COBOL ESQL 4J project. The most important changes include the removal of the pre-commit hook setup, updates to the contributing guidelines to recommend running the `./format` script, and corresponding changes in the Japanese version of the contributing guidelines.

Changes to development environment setup:

* [`.devcontainer/boot.sh`](diffhunk://#diff-119075d89ac87a22250389b2630cec3460f779cf743d289e5658d3e548c47b17L23-L25): Removed the setup for the pre-commit hook.
* [`.devcontainer/term_settings/pre-commit`](diffhunk://#diff-90091b43076cc683310119b096df60c1d2117453c5c05569c7417f33aaa71780L1-L4): Deleted the pre-commit hook script. It is up to each developer to decide whether to use pre-commit.

Updates to contributing guidelines:

* [`CONTRIBUTING.md`](diffhunk://#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055R13-R14): Added a recommendation to run the `./format` script before submitting pull requests and updated the static analysis section to reflect this change. [[1]](diffhunk://#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055R13-R14) [[2]](diffhunk://#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055L29-R34)
* [`CONTRIBUTING_JP.md`](diffhunk://#diff-705b8bb6459eda70c11dfdf8092eaa3d3d5c7cd93b8e62986bf370df0445e910R13-R14): Added a recommendation to run the `./format` script before submitting pull requests and updated the static analysis section to reflect this change in Japanese. [[1]](diffhunk://#diff-705b8bb6459eda70c11dfdf8092eaa3d3d5c7cd93b8e62986bf370df0445e910R13-R14) [[2]](diffhunk://#diff-705b8bb6459eda70c11dfdf8092eaa3d3d5c7cd93b8e62986bf370df0445e910L29-R34)