### PR TITLE
Fix for INCLUDE statement with newlines

### DIFF
--- a/ocesql/scanner.l
+++ b/ocesql/scanner.l
@@ -483,9 +483,15 @@ INT_CONSTANT {digit}+
 	}
 }
 
-"EXEC"[ ]+"SQL"[ ]+"INCLUDE" {
-        period = 0;
-	startlineno = yylineno;
+"EXEC"[ ]+"SQL"[ \r\n]+"INCLUDE" {
+    period = 0;
+	int newlines = 0;
+    for (char *p = yytext; *p != '\0'; p++) {
+        if (*p == '\n') {
+            newlines++;
+        }
+    }
+    startlineno = yylineno - newlines;
 	host_reference_list = NULL;
 	res_host_reference_list = NULL;
 	memset(dbname,0,sizeof(dbname));

--- a/tests/misc.src/include.at
+++ b/tests/misc.src/include.at
@@ -2,16 +2,16 @@ AT_SETUP([include])
 
 AT_DATA([TEST-DATA], [
        01  TEST-DATA.
-         03 FILLER       PIC X(28) VALUE "0001ï¿½kï¿½Cï¿½@ï¿½ï¿½ï¿½Y          0400".
-         03 FILLER       PIC X(28) VALUE "0002ï¿½ÂXï¿½@ï¿½ï¿½ï¿½Y          0350".
-         03 FILLER       PIC X(28) VALUE "0003ï¿½Hï¿½cï¿½@ï¿½Oï¿½Y          0300".
-         03 FILLER       PIC X(28) VALUE "0004ï¿½ï¿½ï¿½@ï¿½lï¿½Y          025p".
-         03 FILLER       PIC X(28) VALUE "0005ï¿½{ï¿½ï¿½@ï¿½Ü˜Y          020p".
-         03 FILLER       PIC X(28) VALUE "0006ï¿½ï¿½ï¿½ï¿½ï¿½@ï¿½Zï¿½Y          0150".
-         03 FILLER       PIC X(28) VALUE "0007ï¿½È–Ø@ï¿½ï¿½ï¿½Y          010p".
-         03 FILLER       PIC X(28) VALUE "0008ï¿½ï¿½ï¿½@ï¿½ï¿½ï¿½Y          0050".
-         03 FILLER       PIC X(28) VALUE "0009ï¿½Qï¿½nï¿½@ï¿½ï¿½Y          020p".
-         03 FILLER       PIC X(28) VALUE "0010ï¿½ï¿½Ê@ï¿½\ï¿½Y          0350".
+         03 FILLER       PIC X(28) VALUE "0001–kŠC@‘¾˜Y          0400".
+         03 FILLER       PIC X(28) VALUE "0002ÂX@ŽŸ˜Y          0350".
+         03 FILLER       PIC X(28) VALUE "0003H“c@ŽO˜Y          0300".
+         03 FILLER       PIC X(28) VALUE "0004ŠâŽè@Žl˜Y          025p".
+         03 FILLER       PIC X(28) VALUE "0005‹{é@ŒÜ˜Y          020p".
+         03 FILLER       PIC X(28) VALUE "0006•Ÿ“‡@˜Z˜Y          0150".
+         03 FILLER       PIC X(28) VALUE "0007“È–Ø@Žµ˜Y          010p".
+         03 FILLER       PIC X(28) VALUE "0008ˆïé@”ª˜Y          0050".
+         03 FILLER       PIC X(28) VALUE "0009ŒQ”n@‹ã˜Y          020p".
+         03 FILLER       PIC X(28) VALUE "0010é‹Ê@\˜Y          0350".
 ])
 
 AT_DATA([TEST-DATA-R], [
@@ -221,12 +221,12 @@ Generate:ROLLBACK
 AT_CHECK([${COMPILE_MODULE} prog.cob])
 AT_CHECK([${RUN_MODULE} prog], [0],
 [0001 <log> success test_return_code
-+0005, ï¿½{ï¿½ï¿½@ï¿½Ü˜Y          , -0200
-+0006, ï¿½ï¿½ï¿½ï¿½ï¿½@ï¿½Zï¿½Y          , +0150
-+0007, ï¿½È–Ø@ï¿½ï¿½ï¿½Y          , -0100
-+0008, ï¿½ï¿½ï¿½@ï¿½ï¿½ï¿½Y          , +0050
-+0009, ï¿½Qï¿½nï¿½@ï¿½ï¿½Y          , -0200
-+0010, ï¿½ï¿½Ê@ï¿½\ï¿½Y          , +0350
++0005, ‹{é@ŒÜ˜Y          , -0200
++0006, •Ÿ“‡@˜Z˜Y          , +0150
++0007, “È–Ø@Žµ˜Y          , -0100
++0008, ˆïé@”ª˜Y          , +0050
++0009, ŒQ”n@‹ã˜Y          , -0200
++0010, é‹Ê@\˜Y          , +0350
 ])
 
 AT_CLEANUP

--- a/tests/misc.src/include.at
+++ b/tests/misc.src/include.at
@@ -2,16 +2,16 @@ AT_SETUP([include])
 
 AT_DATA([TEST-DATA], [
        01  TEST-DATA.
-         03 FILLER       PIC X(28) VALUE "0001–kŠC@‘¾˜Y          0400".
-         03 FILLER       PIC X(28) VALUE "0002ÂX@ŽŸ˜Y          0350".
-         03 FILLER       PIC X(28) VALUE "0003H“c@ŽO˜Y          0300".
-         03 FILLER       PIC X(28) VALUE "0004ŠâŽè@Žl˜Y          025p".
-         03 FILLER       PIC X(28) VALUE "0005‹{é@ŒÜ˜Y          020p".
-         03 FILLER       PIC X(28) VALUE "0006•Ÿ“‡@˜Z˜Y          0150".
-         03 FILLER       PIC X(28) VALUE "0007“È–Ø@Žµ˜Y          010p".
-         03 FILLER       PIC X(28) VALUE "0008ˆïé@”ª˜Y          0050".
-         03 FILLER       PIC X(28) VALUE "0009ŒQ”n@‹ã˜Y          020p".
-         03 FILLER       PIC X(28) VALUE "0010é‹Ê@\˜Y          0350".
+         03 FILLER       PIC X(28) VALUE "0001ï¿½kï¿½Cï¿½@ï¿½ï¿½ï¿½Y          0400".
+         03 FILLER       PIC X(28) VALUE "0002ï¿½ÂXï¿½@ï¿½ï¿½ï¿½Y          0350".
+         03 FILLER       PIC X(28) VALUE "0003ï¿½Hï¿½cï¿½@ï¿½Oï¿½Y          0300".
+         03 FILLER       PIC X(28) VALUE "0004ï¿½ï¿½ï¿½@ï¿½lï¿½Y          025p".
+         03 FILLER       PIC X(28) VALUE "0005ï¿½{ï¿½ï¿½@ï¿½Ü˜Y          020p".
+         03 FILLER       PIC X(28) VALUE "0006ï¿½ï¿½ï¿½ï¿½ï¿½@ï¿½Zï¿½Y          0150".
+         03 FILLER       PIC X(28) VALUE "0007ï¿½È–Ø@ï¿½ï¿½ï¿½Y          010p".
+         03 FILLER       PIC X(28) VALUE "0008ï¿½ï¿½ï¿½@ï¿½ï¿½ï¿½Y          0050".
+         03 FILLER       PIC X(28) VALUE "0009ï¿½Qï¿½nï¿½@ï¿½ï¿½Y          020p".
+         03 FILLER       PIC X(28) VALUE "0010ï¿½ï¿½Ê@ï¿½\ï¿½Y          0350".
 ])
 
 AT_DATA([TEST-DATA-R], [
@@ -221,12 +221,52 @@ Generate:ROLLBACK
 AT_CHECK([${COMPILE_MODULE} prog.cob])
 AT_CHECK([${RUN_MODULE} prog], [0],
 [0001 <log> success test_return_code
-+0005, ‹{é@ŒÜ˜Y          , -0200
-+0006, •Ÿ“‡@˜Z˜Y          , +0150
-+0007, “È–Ø@Žµ˜Y          , -0100
-+0008, ˆïé@”ª˜Y          , +0050
-+0009, ŒQ”n@‹ã˜Y          , -0200
-+0010, é‹Ê@\˜Y          , +0350
++0005, ï¿½{ï¿½ï¿½@ï¿½Ü˜Y          , -0200
++0006, ï¿½ï¿½ï¿½ï¿½ï¿½@ï¿½Zï¿½Y          , +0150
++0007, ï¿½È–Ø@ï¿½ï¿½ï¿½Y          , -0100
++0008, ï¿½ï¿½ï¿½@ï¿½ï¿½ï¿½Y          , +0050
++0009, ï¿½Qï¿½nï¿½@ï¿½ï¿½Y          , -0200
++0010, ï¿½ï¿½Ê@ï¿½\ï¿½Y          , +0350
 ])
+
+AT_CLEANUP
+
+
+AT_SETUP([use include with newline])
+
+AT_DATA([prog.cbl], [
+       IDENTIFICATION              DIVISION.
+      ******************************************************************
+       PROGRAM-ID.                 prog.
+      ******************************************************************
+       DATA                        DIVISION.
+      ******************************************************************
+       WORKING-STORAGE SECTION. 
+       EXEC SQL 
+           INCLUDE SQLCA 
+       END-EXEC.
+       PROCEDURE DIVISION.
+           STOP RUN.
+])
+
+AT_DATA([prog.txt], [
+       IDENTIFICATION              DIVISION.
+      ******************************************************************
+       PROGRAM-ID.                 prog.
+      ******************************************************************
+       DATA                        DIVISION.
+      ******************************************************************
+       WORKING-STORAGE SECTION. 
+OCESQL*EXEC SQL 
+OCESQL*    INCLUDE SQLCA 
+OCESQL*END-EXEC.
+OCESQL     copy "sqlca.cbl".
+OCESQL*
+       PROCEDURE DIVISION.
+           STOP RUN.
+])
+
+AT_CHECK([ocesql prog.cbl prog.cob > /dev/null],[0])
+AT_CHECK([diff prog.cob prog.txt], [0])
 
 AT_CLEANUP


### PR DESCRIPTION
When newlines was included in the INCLUDE statement as shown below, syntax error occurred.
Fixed to precompile even if newlines is included.

```COBOL
       EXEC SQL 
           INCLUDE SQLCA 
       END-EXEC.
```