### PR TITLE
Improve the process of generating coverage reports

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -97,9 +97,9 @@ jobs:
         working-directory: ocesql
         run: |
           gcov -l ./*.gcda
-          gcovr -r . --html -o report.html
+          gcovr -r . --html --html-details --html-self-contained -o report.html --txt-metric=branch
           mkdir coverage-report
-          cp ./*.gcno ./*.gcda ./*.gcov report.html coverage-report
+          cp ./*.html coverage-report
 
       # Upload a coverage report
       - name: Archive a coverage report


### PR DESCRIPTION
This pull request updates the coverage reporting workflow in `.github/workflows/coverage.yml` to enhance the generated reports and streamline the process.

Enhancements to coverage reporting:

* `jobs:` in `.github/workflows/coverage.yml`: Modified the `gcovr` command to include detailed HTML reports with self-contained assets and added branch metrics to the report.
* `jobs:` in `.github/workflows/coverage.yml`: Updated the file copying step to only include HTML files instead of `.gcno`, `.gcda`, and `.gcov` files, simplifying the contents of the `coverage-report` directory.