### PR TITLE
Fix CI trigger

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: tests
 on:
   push:
   pull_request:
-    types: [opened, reopened, review_requested, synchronize]
+    types: [opened, reopened, synchronize]
   workflow_dispatch:
   # Run tests 10:00 PM (JST) every day
   schedule:


### PR DESCRIPTION
I removed the CI trigger `review_requested` from ci.yml.
This prevents duplicate runs of the same pipeline.