### PR TITLE
Fix: Bug in VARYING (variable-length) variables

### DIFF
--- a/dblibj/src/main/scala/Common.scala
+++ b/dblibj/src/main/scala/Common.scala
@@ -904,14 +904,13 @@ object Common {
     val length_bytes = ByteBuffer.wrap(new scala.Array[Byte](4));
     if (str.length >= sv.length) {
       length_bytes.putInt(sv.length)
-      addr.memcpy(0, length_bytes.array(), OCDB_VARCHAR_HEADER_BYTE)
       addr.memcpy(OCDB_VARCHAR_HEADER_BYTE, str, sv.length)
     } else {
       length_bytes.putInt(str.length)
-      addr.memcpy(0, length_bytes.array(), OCDB_VARCHAR_HEADER_BYTE)
       addr.memset(OCDB_VARCHAR_HEADER_BYTE, ' '.toByte, sv.length)
       addr.memcpy(OCDB_VARCHAR_HEADER_BYTE, str, str.length)
     }
+    addr.memcpy(0, length_bytes.array(), OCDB_VARCHAR_HEADER_BYTE)
   }
 
   private def createCobolDataJapaneseVarying(

--- a/dblibj/src/main/scala/Common.scala
+++ b/dblibj/src/main/scala/Common.scala
@@ -904,9 +904,11 @@ object Common {
     val length_bytes = ByteBuffer.wrap(new scala.Array[Byte](4));
     if (str.length >= sv.length) {
       length_bytes.putInt(sv.length)
+      addr.memcpy(0, length_bytes.array(), OCDB_VARCHAR_HEADER_BYTE)
       addr.memcpy(OCDB_VARCHAR_HEADER_BYTE, str, sv.length)
     } else {
       length_bytes.putInt(str.length)
+      addr.memcpy(0, length_bytes.array(), OCDB_VARCHAR_HEADER_BYTE)
       addr.memset(OCDB_VARCHAR_HEADER_BYTE, ' '.toByte, sv.length)
       addr.memcpy(OCDB_VARCHAR_HEADER_BYTE, str, str.length)
     }
@@ -918,7 +920,24 @@ object Common {
       i: Int,
       str: scala.Array[Byte]
   ): Unit = {
-    // TODO Implement
+    val length_bytes = ByteBuffer.wrap(new scala.Array[Byte](4));
+    if (str.length >= sv.length * 2) {
+      length_bytes.putInt(sv.length)
+      addr.memcpy(0, length_bytes.array(), OCDB_VARCHAR_HEADER_BYTE)
+      addr.memcpy(OCDB_VARCHAR_HEADER_BYTE, str, sv.length * 2)
+    } else {
+      val length = sv.length
+      val arr = scala.Array(0x81.toByte, 0x40.toByte)
+      for (
+        i <-
+          OCDB_VARCHAR_HEADER_BYTE until (OCDB_VARCHAR_HEADER_BYTE + length * 2 - 1) by 2
+      ) {
+        addr.memcpy(i, arr, 2)
+      }
+      length_bytes.putInt(str.length / 2)
+      addr.memcpy(0, length_bytes.array(), OCDB_VARCHAR_HEADER_BYTE)
+      addr.memcpy(OCDB_VARCHAR_HEADER_BYTE, str, str.length)
+    }
   }
 
   // scalastyle:off method.length

--- a/dblibj/src/main/scala/Main.scala
+++ b/dblibj/src/main/scala/Main.scala
@@ -783,6 +783,12 @@ class OCESQLCursorFetchOne extends CobolRunnableWrapper {
       for ((sv, i) <- state.globalState.sqlResVarQueue.zipWithIndex) {
         if (i < fields) {
           fetchRecord = fetchRecord ::: List(ocdbGetValue(rs, sv, i + 1))
+          if (
+            sv.sqlVarType == OCDB_TYPE_ALPHANUMERIC_VARYING || sv.sqlVarType == OCDB_TYPE_JAPANESE_VARYING
+          ) {
+            val byteArray: Array[Byte] = fetchRecord.flatten.flatten.toArray
+            createCobolData(sv, 0, byteArray, state.globalState.occursInfo)
+          }
         }
       }
       fetchRecords = fetchRecords ::: List(fetchRecord)

--- a/dblibj/src/main/scala/SQLVar.scala
+++ b/dblibj/src/main/scala/SQLVar.scala
@@ -173,8 +173,8 @@ object SQLVar {
       case OCDB_TYPE_JAPANESE           => createRealDataJapanese(x)
       case OCDB_TYPE_ALPHANUMERIC_VARYING =>
         createRealDataAlphanumericVarying(x)
-      // case OCDB_TYPE_JAPANESE_VARYING => createRealDataJapaneseVarying(x)
-      case _ => createRealDataDefault(x)
+      case OCDB_TYPE_JAPANESE_VARYING => createRealDataJapaneseVarying(x)
+      case _                          => createRealDataDefault(x)
     }
   }
 
@@ -493,7 +493,25 @@ object SQLVar {
       .setLength(lenSize)
   }
 
-  private def createRealDataJapaneseVarying(v: SQLVar): SQLVar = v
+  private def createRealDataJapaneseVarying(v: SQLVar): SQLVar = {
+    val addr = v.addr.getOrElse(nullDataStorage)
+    val addrDataPart = addr.getSubDataStorage(OCDB_VARCHAR_HEADER_BYTE);
+    var lenSize = 0;
+    for (i <- 0 to OCDB_VARCHAR_HEADER_BYTE - 1) {
+      lenSize = lenSize * 256 + java.lang.Byte.toUnsignedInt(addr.getByte(i))
+    }
+    lenSize *= 2
+    val data = new CobolDataStorage(lenSize + 1)
+    val realData = new CobolDataStorage(lenSize + 1)
+    data.memset(0.toByte, lenSize + 1)
+    realData.memset(0.toByte, lenSize + 1)
+    data.memcpy(addrDataPart, lenSize)
+    realData.memcpy(addrDataPart, lenSize)
+    v.setRealData(Some(realData))
+      .setData(Some(data))
+      .setRealDataLength(lenSize)
+      .setLength(lenSize)
+  }
 
   private def createRealDataDefault(v: SQLVar): SQLVar = {
     val data = new CobolDataStorage(v.length)

--- a/ocesql/ppout.c
+++ b/ocesql/ppout.c
@@ -1436,7 +1436,11 @@ void ppbuff(struct cb_exec_list *list) {
     com_strcat(out, sizeof(out), vtmp);
     com_strcat(out, sizeof(out), " ");
     com_strcat(out, sizeof(out), vp_arr->sname);
-    com_strcat(out, sizeof(out), " PIC X(");
+    if (vp_parent->pictype == PIC_NATIONAL_VARYING) {
+      com_strcat(out, sizeof(out), " PIC N(");
+    } else {
+      com_strcat(out, sizeof(out), " PIC X(");
+    }
     com_sprintf(vtmp, sizeof(vtmp), "%d", vp_arr->picnsize);
     com_strcat(out, sizeof(out), vtmp);
     com_strcat(out, sizeof(out), ").");

--- a/tests/cobol_data.src/varying.at
+++ b/tests/cobol_data.src/varying.at
@@ -711,12 +711,12 @@ AT_DATA([prog.cbl], [
       ******************************************************************
 
       *    SERVER
-      　    MOVE  "<|DB_NAME|>@<|DB_HOST|>:<|DB_PORT|>"
-      　      TO DBNAME.
-      　    MOVE  "<|DB_USER|>"
-      　      TO USERNAME.
-      　    MOVE  "<|DB_PASSWORD|>"
-      　      TO PASSWD.
+           MOVE  "<|DB_NAME|>@<|DB_HOST|>:<|DB_PORT|>"
+             TO DBNAME.
+           MOVE  "<|DB_USER|>"
+             TO USERNAME.
+           MOVE  "<|DB_PASSWORD|>"
+             TO PASSWD.
 
            EXEC SQL
                CONNECT :USERNAME IDENTIFIED BY :PASSWD USING :DBNAME 

--- a/tests/cobol_data.src/varying.at
+++ b/tests/cobol_data.src/varying.at
@@ -54,7 +54,7 @@ AT_DATA([prog.cbl], [
       *    PERFORM DISPLAY-TEST-RESULT.
            PERFORM UNTIL SQLCODE NOT = ZERO
               DISPLAY EMP-NAME-ARR
-              MOVE IDX TO EMP-NAME-LEN
+              DISPLAY EMP-NAME-LEN
               EXEC SQL 
                   FETCH C1 INTO :EMP-NUM1, :EMP-NAME, :EMP-NUM2
               END-EXEC
@@ -420,6 +420,435 @@ AT_CHECK([${RUN_MODULE} prog], [0],
 012345678 @&t@
 +00000009
 0123456789
++00000010
+])
+
+AT_CLEANUP
+
+
+AT_SETUP([varying japanese])
+
+AT_DATA([prog.cbl], [
+       IDENTIFICATION              DIVISION.
+      ******************************************************************
+       PROGRAM-ID.                 prog.
+      ******************************************************************
+       DATA                        DIVISION.
+      ******************************************************************
+       WORKING-STORAGE             SECTION.
+       01  TEST-DATA.
+         03 FILLER  PIC X(28) VALUE "0000一　　　　　　　　　9990".
+         03 FILLER  PIC X(28) VALUE "0001一二　　　　　　　　9991".
+         03 FILLER  PIC X(28) VALUE "0002一二三　　　　　　　9992".
+         03 FILLER  PIC X(28) VALUE "0003一二三四　　　　　　9993".
+         03 FILLER  PIC X(28) VALUE "0004一二三四五　　　　　9994".
+         03 FILLER  PIC X(28) VALUE "0005一二三四五六　　　　9995".
+         03 FILLER  PIC X(28) VALUE "0006一二三四五六七　　　9996".
+         03 FILLER  PIC X(28) VALUE "0007一二三四五六七八　　9997".
+         03 FILLER  PIC X(28) VALUE "0008一二三四五六七八九　9998".
+         03 FILLER  PIC X(28) VALUE "0009一二三四五六七八九十9999".
+
+       01  TEST-DATA-R   REDEFINES TEST-DATA.
+         03  TEST-TBL    OCCURS  10.
+           05  TEST-NUM1           PIC  9(04).
+           05  TEST-NAME           PIC  N(10).
+           05  TEST-NUM2           PIC  9(04).
+       01  IDX                     PIC  9(02).
+       01 TEST-CASE-COUNT PIC 9999 VALUE 1.
+
+       EXEC SQL BEGIN DECLARE SECTION END-EXEC.
+       01  DBNAME                  PIC  X(30) VALUE SPACE.
+       01  USERNAME                PIC  X(30) VALUE SPACE.
+       01  PASSWD                  PIC  X(10) VALUE SPACE.
+
+       01  EMP-REC-VARS.
+         03  EMP-NUM1              PIC  9(4).
+         03  EMP-NAME              PIC  N(10) VARYING.
+         03  EMP-NUM2              PIC  9(4).
+       EXEC SQL END DECLARE SECTION END-EXEC.
+
+       EXEC SQL INCLUDE SQLCA END-EXEC.
+      ******************************************************************
+       PROCEDURE                   DIVISION.
+      ******************************************************************
+       MAIN-RTN.
+           
+       PERFORM SETUP-DB.
+
+           EXEC SQL 
+               FETCH C1 INTO :EMP-NUM1, :EMP-NAME, :EMP-NUM2
+           END-EXEC.
+
+      *    PERFORM DISPLAY-TEST-RESULT.
+           PERFORM UNTIL SQLCODE NOT = ZERO
+              DISPLAY EMP-NAME-ARR
+              DISPLAY EMP-NAME-LEN
+              MOVE IDX TO EMP-NAME-LEN
+              EXEC SQL 
+                  FETCH C1 INTO :EMP-NUM1, :EMP-NAME, :EMP-NUM2
+              END-EXEC
+      *        PERFORM DISPLAY-TEST-RESULT
+           END-PERFORM.
+
+       PERFORM CLEANUP-DB.
+
+      *    END
+           STOP RUN.
+
+      ******************************************************************
+       SETUP-DB.
+      ******************************************************************
+
+      *    SERVER
+           MOVE  "<|DB_NAME|>@<|DB_HOST|>:<|DB_PORT|>"
+             TO DBNAME.
+           MOVE  "<|DB_USER|>"
+             TO USERNAME.
+           MOVE  "<|DB_PASSWORD|>"
+             TO PASSWD.
+
+           EXEC SQL
+               CONNECT :USERNAME IDENTIFIED BY :PASSWD USING :DBNAME 
+           END-EXEC.
+
+           EXEC SQL
+               DROP TABLE IF EXISTS EMP
+           END-EXEC.
+
+           EXEC SQL
+                CREATE TABLE EMP
+                (
+                    EMP_NUM1   NUMERIC(4, 0),
+                    EMP_NAME   VARCHAR(10),
+                    EMP_NUM2   NUMERIC(4, 0)
+                )
+           END-EXEC.
+
+      *    INSERT ROWS USING HOST VARIABLE
+           PERFORM VARYING IDX FROM 1 BY 1 UNTIL IDX > 10
+              MOVE TEST-NUM1(IDX)   TO  EMP-NUM1
+              MOVE TEST-NAME(IDX)   TO  EMP-NAME-ARR
+              MOVE TEST-NUM2(IDX)   TO  EMP-NUM2
+              MOVE IDX TO EMP-NAME-LEN
+              EXEC SQL
+                 INSERT INTO EMP VALUES
+                        (:EMP-NUM1, :EMP-NAME, :EMP-NUM2)
+              END-EXEC
+      *       PERFORM DISPLAY-TEST-RESULT
+           END-PERFORM.
+      *    DECLARE CURSOR
+           EXEC SQL 
+               DECLARE C1 CURSOR FOR
+               SELECT EMP_NUM1, EMP_NAME, EMP_NUM2
+                      FROM EMP
+                      ORDER BY EMP_NUM1
+           END-EXEC.
+
+      *    OPEN CURSOR
+           EXEC SQL
+               OPEN C1
+           END-EXEC.
+
+      ******************************************************************
+       CLEANUP-DB.
+      ******************************************************************
+           EXEC SQL
+               CLOSE C1
+           END-EXEC.
+
+           EXEC SQL
+               DROP TABLE IF EXISTS EMP
+           END-EXEC.
+
+           EXEC SQL
+               DISCONNECT ALL
+           END-EXEC.
+
+      ******************************************************************
+       DISPLAY-TEST-RESULT.
+      ******************************************************************
+           IF  SQLCODE = ZERO
+             THEN
+
+               DISPLAY "<log> test case " TEST-CASE-COUNT ": success"
+               ADD 1 TO TEST-CASE-COUNT
+
+             ELSE
+               DISPLAY "*** SQL ERROR ***"
+               DISPLAY "SQLCODE: " SQLCODE " " NO ADVANCING
+               EVALUATE SQLCODE
+                  WHEN  +10
+                     DISPLAY "Record not found"
+                  WHEN  -01
+                     DISPLAY "Connection falied"
+                  WHEN  -20
+                     DISPLAY "Internal error"
+                  WHEN  -30
+                     DISPLAY "PostgreSQL error"
+                     DISPLAY "ERRCODE: "  SQLSTATE
+                     DISPLAY SQLERRMC
+                  *> TO RESTART TRANSACTION, DO ROLLBACK.
+                     EXEC SQL
+                         ROLLBACK
+                     END-EXEC
+                  WHEN  OTHER
+                     DISPLAY "Undefined error"
+                     DISPLAY "ERRCODE: "  SQLSTATE
+                     DISPLAY SQLERRMC
+               END-EVALUATE
+               STOP RUN.
+      ******************************************************************  
+])
+
+AT_CHECK([${EMBED_DB_INFO} prog.cbl])
+AT_CHECK([ocesql prog.cbl prog.cob], [0],
+[precompile start: prog.cbl
+=======================================================
+              LIST OF CALLED DB Library API            @&t@
+=======================================================
+Generate:OCESQLCursorFetchOne
+Generate:OCESQLCursorFetchOne
+Generate:OCESQLConnect
+Generate:OCESQLExec
+Generate:OCESQLExec
+Generate:OCESQLExecParams
+Generate:OCESQLCursorDeclare
+Generate:OCESQLCursorOpen
+Generate:OCESQLCursorClose
+Generate:OCESQLExec
+Generate:OCESQLDisconnect
+Generate:ROLLBACK
+=======================================================
+])
+AT_CHECK([${COMPILE_MODULE} prog.cob])
+AT_CHECK([${RUN_MODULE} prog], [0],
+[一　　　　　　　　　@&t@
++00000001
+一二　　　　　　　　@&t@
++00000002
+一二三　　　　　　　@&t@
++00000003
+一二三四　　　　　　@&t@
++00000004
+一二三四五　　　　　@&t@
++00000005
+一二三四五六　　　　@&t@
++00000006
+一二三四五六七　　　@&t@
++00000007
+一二三四五六七八　　@&t@
++00000008
+一二三四五六七八九　@&t@
++00000009
+一二三四五六七八九十
++00000010
+])
+
+AT_DATA([prog.cbl], [
+       IDENTIFICATION              DIVISION.
+      ******************************************************************
+       PROGRAM-ID.                 prog.
+      ******************************************************************
+       DATA                        DIVISION.
+      ******************************************************************
+       WORKING-STORAGE             SECTION.
+       01  TEST-DATA.
+         03 FILLER       PIC N(10) VALUE "一".
+         03 FILLER       PIC N(10) VALUE "一二".
+         03 FILLER       PIC N(10) VALUE "一二三".
+         03 FILLER       PIC N(10) VALUE "一二三四".
+         03 FILLER       PIC N(10) VALUE "一二三四五".
+         03 FILLER       PIC N(10) VALUE "一二三四五六".
+         03 FILLER       PIC N(10) VALUE "一二三四五六七".
+         03 FILLER       PIC N(10) VALUE "一二三四五六七八".
+         03 FILLER       PIC N(10) VALUE "一二三四五六七八九".
+         03 FILLER       PIC N(10) VALUE "一二三四五六七八九十".
+
+       01  TEST-DATA-R   REDEFINES TEST-DATA.
+         03  TEST-TBL    OCCURS  10.
+           05  TEST-NAME           PIC  N(10).
+       01  IDX                     PIC  9(02).
+       01 TEST-CASE-COUNT PIC 9999 VALUE 1.
+
+       EXEC SQL BEGIN DECLARE SECTION END-EXEC.
+       01  DBNAME                  PIC  X(30) VALUE SPACE.
+       01  USERNAME                PIC  X(30) VALUE SPACE.
+       01  PASSWD                  PIC  X(10) VALUE SPACE.
+
+       01  EMP-REC-VARS.
+         03  EMP-NAME              PIC  N(10) VARYING.
+       EXEC SQL END DECLARE SECTION END-EXEC.
+
+       EXEC SQL INCLUDE SQLCA END-EXEC.
+      ******************************************************************
+       PROCEDURE                   DIVISION.
+      ******************************************************************
+       MAIN-RTN.
+           
+       PERFORM SETUP-DB.
+
+           EXEC SQL 
+               FETCH C1 INTO :EMP-NAME
+           END-EXEC.
+
+      *    PERFORM DISPLAY-TEST-RESULT.
+           PERFORM UNTIL SQLCODE NOT = ZERO
+              DISPLAY EMP-NAME-ARR
+              DISPLAY EMP-NAME-LEN
+              EXEC SQL 
+                  FETCH C1 INTO :EMP-NAME
+              END-EXEC
+      *        PERFORM DISPLAY-TEST-RESULT
+           END-PERFORM.
+
+       PERFORM CLEANUP-DB.
+
+      *    END
+           STOP RUN.
+
+      ******************************************************************
+       SETUP-DB.
+      ******************************************************************
+
+      *    SERVER
+      　    MOVE  "<|DB_NAME|>@<|DB_HOST|>:<|DB_PORT|>"
+      　      TO DBNAME.
+      　    MOVE  "<|DB_USER|>"
+      　      TO USERNAME.
+      　    MOVE  "<|DB_PASSWORD|>"
+      　      TO PASSWD.
+
+           EXEC SQL
+               CONNECT :USERNAME IDENTIFIED BY :PASSWD USING :DBNAME 
+           END-EXEC.
+
+           EXEC SQL
+               DROP TABLE IF EXISTS EMP
+           END-EXEC.
+
+           EXEC SQL
+                CREATE TABLE EMP
+                (
+                    EMP_NAME   VARCHAR(10)
+                )
+           END-EXEC.
+
+      *    INSERT ROWS USING HOST VARIABLE
+           PERFORM VARYING IDX FROM 1 BY 1 UNTIL IDX > 10
+              MOVE TEST-NAME(IDX)   TO  EMP-NAME-ARR
+              MOVE IDX TO EMP-NAME-LEN
+              EXEC SQL
+                 INSERT INTO EMP VALUES
+                        (:EMP-NAME)
+              END-EXEC
+      *       PERFORM DISPLAY-TEST-RESULT
+           END-PERFORM.
+      *    DECLARE CURSOR
+           EXEC SQL 
+               DECLARE C1 CURSOR FOR
+               SELECT EMP_NAME
+                      FROM EMP
+                      ORDER BY EMP_NAME
+           END-EXEC.
+
+      *    OPEN CURSOR
+           EXEC SQL
+               OPEN C1
+           END-EXEC.
+
+      ******************************************************************
+       CLEANUP-DB.
+      ******************************************************************
+           EXEC SQL
+               CLOSE C1
+           END-EXEC.
+
+           EXEC SQL
+               DROP TABLE IF EXISTS EMP
+           END-EXEC.
+
+           EXEC SQL
+               DISCONNECT ALL
+           END-EXEC.
+
+      ******************************************************************
+       DISPLAY-TEST-RESULT.
+      ******************************************************************
+           IF  SQLCODE = ZERO
+             THEN
+
+               DISPLAY "<log> test case " TEST-CASE-COUNT ": success"
+               ADD 1 TO TEST-CASE-COUNT
+
+             ELSE
+               DISPLAY "*** SQL ERROR ***"
+               DISPLAY "SQLCODE: " SQLCODE " " NO ADVANCING
+               EVALUATE SQLCODE
+                  WHEN  +10
+                     DISPLAY "Record not found"
+                  WHEN  -01
+                     DISPLAY "Connection falied"
+                  WHEN  -20
+                     DISPLAY "Internal error"
+                  WHEN  -30
+                     DISPLAY "PostgreSQL error"
+                     DISPLAY "ERRCODE: "  SQLSTATE
+                     DISPLAY SQLERRMC
+                  *> TO RESTART TRANSACTION, DO ROLLBACK.
+                     EXEC SQL
+                         ROLLBACK
+                     END-EXEC
+                  WHEN  OTHER
+                     DISPLAY "Undefined error"
+                     DISPLAY "ERRCODE: "  SQLSTATE
+                     DISPLAY SQLERRMC
+               END-EVALUATE
+               STOP RUN.
+      ******************************************************************  
+
+])
+
+AT_CHECK([${EMBED_DB_INFO} prog.cbl])
+AT_CHECK([ocesql prog.cbl prog.cob], [0],
+[precompile start: prog.cbl
+=======================================================
+              LIST OF CALLED DB Library API            @&t@
+=======================================================
+Generate:OCESQLCursorFetchOne
+Generate:OCESQLCursorFetchOne
+Generate:OCESQLConnect
+Generate:OCESQLExec
+Generate:OCESQLExec
+Generate:OCESQLExecParams
+Generate:OCESQLCursorDeclare
+Generate:OCESQLCursorOpen
+Generate:OCESQLCursorClose
+Generate:OCESQLExec
+Generate:OCESQLDisconnect
+Generate:ROLLBACK
+=======================================================
+])
+AT_CHECK([${COMPILE_MODULE} prog.cob])
+AT_CHECK([${RUN_MODULE} prog], [0],
+[一　　　　　　　　　@&t@
++00000001
+一二　　　　　　　　@&t@
++00000002
+一二三　　　　　　　@&t@
++00000003
+一二三四　　　　　　@&t@
++00000004
+一二三四五　　　　　@&t@
++00000005
+一二三四五六　　　　@&t@
++00000006
+一二三四五六七　　　@&t@
++00000007
+一二三四五六七八　　@&t@
++00000008
+一二三四五六七八九　@&t@
++00000009
+一二三四五六七八九十
 +00000010
 ])
 


### PR DESCRIPTION
# Summary
- Fixed a bug that prevented the string length of a VARYING variable from being fetched correctly. As a result, the previously failing 'varying' tests now pass.
- Implemented support for `PIC N` type VARYING variables.

# Details
## Change 1
Processing for `VARYING` variables is handled by the `createCobolDataAlphanumericVarying` method, which is called from `createCobolData` in `Common.scala`.

The previous code was missing a call to `createCobolData` when a `VARYING` variable was used. This has been fixed by adding the necessary call within `OCESQLCursorFetchOne` in `Main.scala`.

## Change 2
Processing for `PIC N` VARYING variables is handled by `createCobolDataJapaneseVarying` in `Common.scala` and `createRealDataJapaneseVarying` in `SQLVar.scala`. These methods were previously unimplemented and have now been implemented.

This implementation references the existing implementation in `OCESQL`.
- [create_coboldata in OCESQL](https://github.com/opensourcecobol/Open-COBOL-ESQL/blob/09ffffde3c5a704a04ae808d1c70033d17bc5c90/dblib/ocesql.c#L3175)
- [create_realdata in OCESQL](https://github.com/opensourcecobol/Open-COBOL-ESQL/blob/09ffffde3c5a704a04ae808d1c70033d17bc5c90/dblib/ocesql.c#L2686)

## Change 3
- Updated some of the existing `varying` tests.
- Added new tests for `PIC N` VARYING variables.