### PR TITLE
Use the label `windows-2022` instead of `windows-latest`

### DIFF
--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   test:
-    runs-on: windows-latest
+    runs-on: windows-2022
 
     steps:
     - uses: actions/checkout@v5


### PR DESCRIPTION
This PR is a quick fix of #137 by using windows-2022 instead of windows-latest.
In the future, we should update build configurations on Windows in order to successfully build opensource COBOL 4J on GitHub runners labeled `windows-latest`.