### PR TITLE
ci: change conditions of launching schedule runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,7 @@ permissions:
 
 jobs:
   check-workflows:
+    if: github.event_name != 'schedule' || github.repository == 'opensourcecobol/Open-COBOL-ESQL-4j'
     uses: ./.github/workflows/check-workflows.yml
 
   test:
@@ -22,17 +23,14 @@ jobs:
   
   coverage:
     needs: check-workflows
-    if: github.event_name != 'schedule'
     uses: ./.github/workflows/coverage.yml
    
   static_analysis:
     needs: check-workflows
-    if: github.event_name != 'schedule'
     uses: ./.github/workflows/static_analysis.yml 
 
   doc:
     needs: check-workflows
-    if: github.event_name != 'schedule'
     uses: ./.github/workflows/doc.yml
     
   windows-build:


### PR DESCRIPTION
This pull request updates the CI workflow configuration in `.github/workflows/ci.yml` to refine when certain jobs run, particularly in relation to scheduled events and repository targeting.

Due to this change, scheduled runs will not be executed in forked repositories and #141 will be resolved.

Workflow trigger logic updates:

* Added a condition to the `check-workflows` job so it only runs on scheduled events if the repository is `opensourcecobol/Open-COBOL-ESQL-4j`, preventing unnecessary workflow checks on forks during scheduled runs.
* Removed the conditional `if: github.event_name != 'schedule'` from the `coverage`, `static_analysis`, and `doc` jobs, allowing these jobs to run on all event types, including scheduled events.