### PR TITLE
fix: the option`--version`

### DIFF
--- a/ocesql/ocesql.c
+++ b/ocesql/ocesql.c
@@ -277,8 +277,8 @@ char *cb_get_env(const char *filename, int num) {
 }
 
 void version(void) {
-  printf("Open COBOL ESQL 4J\n");
-  printf("Version 1.1.2\n");
+  printf("%s\n", PACKAGE_NAME);
+  printf("Version %s\n", PACKAGE_VERSION);
 #ifdef I18N_UTF8
   printf("[unicode/utf-8 support]\n");
 #endif /* I18N_UTF8 */


### PR DESCRIPTION
This pull request updates the version display logic in the `version` function to use dynamic package name and version information instead of hardcoded strings.
After merging this pull request, we should replace the release 1.1.3 with the new version since the `ocesql --help` shows `1.1.2` of the current version 1.1.3. 

Version display improvements:

* Updated the `version` function in `ocesql/ocesql.c` to print the package name and version using the `PACKAGE_NAME` and `PACKAGE_VERSION` macros instead of hardcoded values.